### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwm-royarg-git
 	pkgdesc = A modified version of the dynamic window manager for X.
-	pkgver = 6.3.r16.30f73ae
+	pkgver = 6.3.r17.95c4d94
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwm
 	install = dwm-royarg-git.install

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwm"
 pkgname="$_pkgname-royarg-git"
-pkgver=6.3.r16.30f73ae
+pkgver=6.3.r17.95c4d94
 pkgrel=1
 pkgdesc="A modified version of the dynamic window manager for X."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit 95c4d9414df615cb53c2a84b18cb78d2358f296d
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Sep 10 14:32:15 2022 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit c2b748e7931e5f28984efc236f9b1a212dbc65e8
    Author: Stein <bakkeby@gmail.com>
    Date:   Fri Aug 26 14:48:46 2022 +0200

        Remove dmenumon variable

        Reasoning: Since 2011 dmenu has been capable of working out which
        monitor currently has focus in a Xinerama setup, making the use
        of the -m flag more or less redundant.

        This is easily demonstrated by using dmenu in any other window
        manager.

        There used to be a nodmenu patch that provided these changes:
        https://git.suckless.org/sites/commit/ed68e3629de4ef2ca2d3f8893a79fb570b4c0cbc.html

        but this was removed on the basis that it was very easy to work
        out and apply manually if needed.

        The proposal here is to remove this dependency from dwm. The
        mechanism of the dmenumon variable could be provided via a patch
        if need be.

        The edge case scenario that dmenu does not handle on its own, and
        the effect of removing this mechanism, is that if the user trigger
        focusmon via keybindings to change focus to another monitor that
        has no clients, then dmenu will open on the monitor containing the
        window with input focus (or the monitor with the mouse cursor if
        no windows have input focus).

        If this edge case is important to cover then this can be addressed
        by setting input focus to selmon->barwin in the focus function if
        there is no client to give focus to (rather than giving focus back
        to the root window).

