### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwm-royarg-git
 	pkgdesc = A modified version of the dynamic window manager for X.
-	pkgver = 6.4.r0.722c435
+	pkgver = 6.4.r1.a721d63
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwm
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwm"
 pkgname="$_pkgname-royarg-git"
-pkgver=6.4.r0.722c435
+pkgver=6.4.r1.a721d63
 pkgrel=1
 pkgdesc="A modified version of the dynamic window manager for X."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit a721d632187f78ee9ed855e44579a2ca2d94293e
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Nov 5 12:06:38 2022 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit ba56fe9fea0a28d8184a727a987836a0903e2682
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Oct 28 16:37:56 2022 +0200

        Revert "Remove dmenumon variable"

        This reverts commit c2b748e7931e5f28984efc236f9b1a212dbc65e8.

        Revert back this change. It seems to not be an edge-case anymore since
        multiple users have asked about this new behaviour now.
