### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwm-royarg-git
 	pkgdesc = A modified version of the dynamic window manager for X.
-	pkgver = 6.4.r1.a721d63
+	pkgver = 6.4.r2.cca54a5
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwm
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwm"
 pkgname="$_pkgname-royarg-git"
-pkgver=6.4.r1.a721d63
+pkgver=6.4.r2.cca54a5
 pkgrel=1
 pkgdesc="A modified version of the dynamic window manager for X."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit cca54a5724e5ff6ab783efe30b68b53d5c8deba8
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Fri Dec 23 20:49:28 2022 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit 89f9905714c1c1b2e8b09986dfbeca15b68d8af8
    Author: Chris Down <chris@chrisdown.name>
    Date:   Wed Dec 7 14:55:08 2022 +0000

        grabkeys: Avoid missing events when a keysym maps to multiple keycodes

        It's not uncommon for one keysym to map to multiple keycodes. For
        example, the "play" button on my keyboard sends keycode 172, but my
        bluetooth headphones send keycode 208, both of which map back to
        XF86AudioPlay:

            % xmodmap -pke | grep XF86AudioPlay
            keycode 172 = XF86AudioPlay XF86AudioPause XF86AudioPlay XF86AudioPause
            keycode 208 = XF86AudioPlay NoSymbol XF86AudioPlay
            keycode 215 = XF86AudioPlay NoSymbol XF86AudioPlay

        This is a problem because the current code only grabs a single one of
        these keycodes, which means that events for any other keycode also
        mapping to the bound keysym will not be handled by dwm. In my case, this
        means that binding XF86AudioPlay does the right thing and correctly
        handles my keyboard's keys, but does nothing on my headphones. I'm not
        the only person affected by this, there are other reports[0].

        In order to fix this, we look at the mappings between keycodes and
        keysyms at grabkeys() time and pick out all matching keycodes rather
        than just the first one. The keypress() side of this doesn't need any
        changes because the keycode gets converted back to a canonical keysym
        before any action is taken.

        0: https://github.com/cdown/dwm/issues/11

