### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwm-royarg-git
 	pkgdesc = A modified version of the dynamic window manager for X.
-	pkgver = 6.4.r2.cca54a5
+	pkgver = 6.4.r3.3b70e15
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwm
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwm"
 pkgname="$_pkgname-royarg-git"
-pkgver=6.4.r2.cca54a5
+pkgver=6.4.r3.3b70e15
 pkgrel=1
 pkgdesc="A modified version of the dynamic window manager for X."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit 3b70e150a309c933c073acadc5f01466168c163d
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Tue Jan 31 20:40:51 2023 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit 712d6639ff8e863560328131bbb92b248dc9cde7
    Author: Chris Down <chris@chrisdown.name>
    Date:   Sat Jan 28 12:53:48 2023 +0100

        Use sigaction(SA_NOCLDWAIT) for SIGCHLD handling

        signal() semantics are pretty unclearly specified. For example, depending on OS
        kernel and libc, the handler may be returned to SIG_DFL (hence the inner call
        to read the signal handler). Moving to sigaction() means the behaviour is
        consistently defined.

        Using SA_NOCLDWAIT also allows us to avoid calling the non-reentrant function
        die() in the handler.

        Some addditional notes for archival purposes:

        * NRK pointed out errno of waitpid could also theoretically get clobbered.
        * The original patch was iterated on and modified by NRK and Hiltjo:
          * SIG_DFL was changed to SIG_IGN, this is required, atleast on older systems
            such as tested on Slackware 11.
          * signals are not blocked using sigprocmask, because in theory it would
            briefly for example also ignore a SIGTERM signal. It is OK if waitpid() is (in
            theory interrupted).

        POSIX reference:
        "Consequences of Process Termination":
        https://pubs.opengroup.org/onlinepubs/9699919799/functions/_Exit.html#tag_16_01_03_01