### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwm-royarg-git
 	pkgdesc = A modified version of the dynamic window manager for X.
-	pkgver = 6.4.r3.3b70e15
+	pkgver = 6.4.r4.d05bb7e
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwm
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwm"
 pkgname="$_pkgname-royarg-git"
-pkgver=6.4.r3.3b70e15
+pkgver=6.4.r4.d05bb7e
 pkgrel=1
 pkgdesc="A modified version of the dynamic window manager for X."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit d05bb7eb3cc23a76ae29fa098c96c22259128dc6
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Tue Mar 7 15:19:57 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 348f6559ab0d4793db196ffa56ba96ab95a594a6
    Author: NRK <nrk@disroot.org>
    Date:   Fri Feb 17 11:05:09 2023 +0600
    
        config.mk: update to _XOPEN_SOURCE=700L
    
        SA_NOCLDWAIT is marked as XSI in the posix spec [0] and FreeBSD and NetBSD
        seems to more be strict about the feature test macro [1].
    
        so update the macro to use _XOPEN_SOURCE=700L instead, which is equivalent to
        _POSIX_C_SOURCE=200809L except that it also unlocks the X/Open System
        Interfaces.
    
        [0]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html#tag_13_42
        [1]: https://lists.suckless.org/dev/2302/35111.html
    
        Tested on:
        * NetBSD 9.3 (fixed).
        * FreeBSD 13 (fixed).
        * Void Linux musl.
        * Void Linux glibc.
        * OpenBSD 7.2 (stable).
        * Slackware 11.
    
        Reported-by: beastie <pufferfish@riseup.net>

