### PR TITLE
Updates from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwm-royarg-git
 	pkgdesc = A modified version of the dynamic window manager for X.
-	pkgver = 6.4.r5.0c14dce
+	pkgver = 6.4.r6.55dc23f
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwm
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwm"
 pkgname="$_pkgname-royarg-git"
-pkgver=6.4.r5.0c14dce
+pkgver=6.4.r6.55dc23f
 pkgrel=1
 pkgdesc="A modified version of the dynamic window manager for X."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit 55dc23facb14da4e7f806332571636e5e902f2eb
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Wed Apr 12 15:02:43 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit e81f17d4c196aaed6893fd4beed49991caa3e2a4
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Sun Apr 9 12:37:14 2023 +0200
    
        restore SIGCHLD sighandler to default before spawning a program
    
        From sigaction(2):
        A child created via fork(2) inherits a copy of its parent's signal dispositions.
        During an execve(2), the dispositions of handled signals are reset to the default;
        the dispositions of ignored signals are left unchanged.
    
        This refused to start directly some programs from configuring in config.h:
    
        static Key keys[] = {
            MODKEY,                       XK_o,      spawn,          {.v = cmd } },
        };
    
        Some reported programs that didn't start were: mpv, anki, dmenu_extended.
    
        Reported by pfx.
        Initial patch suggestion by Storkman.
